### PR TITLE
Rescalabletrail

### DIFF
--- a/Application/Application.iml
+++ b/Application/Application.iml
@@ -8,14 +8,5 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="gson-2.8.2" level="project" />
-        <orderEntry type="module-library" exported="">
-      <library> 
-        <CLASSES> 
-          <root url="jar://$MODULE_DIR$/lib/gson-2.8.2.jar!/" /> 
-        </CLASSES> 
-        </CLASSES> 
-        <SOURCES /> 
-      </library> 
-    </orderEntry> 
   </component>
 </module>

--- a/Application/src/view/visuals/Draw.java
+++ b/Application/src/view/visuals/Draw.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
  * @version 2.1
  * @author Pontus Laestadius, Sebastian Fransson
  * Collaborators Rashad Kamsheh, Kosara Golemshinska, Isabelle Törnqvist
- * Touched by Tim Jonasson
  */
 
 public class Draw {

--- a/Application/src/view/visuals/Draw.java
+++ b/Application/src/view/visuals/Draw.java
@@ -262,7 +262,7 @@ public class Draw {
             // Changes the coordinates of the messages.
             int oldClassSize = message.getClass_size();
             message.changeCoordinates(node1, node2, class_size);
-            //message.resizeTrail(oldClassSize);
+            message.resizeTrail(oldClassSize);
         }
     }
 

--- a/Application/src/view/visuals/Draw.java
+++ b/Application/src/view/visuals/Draw.java
@@ -260,7 +260,9 @@ public class Draw {
             Coordinates node1 = allClasses.get(message.getFromNode()).getCoordinates();
             Coordinates node2 = allClasses.get(message.getToNode()).getCoordinates();
             // Changes the coordinates of the messages.
+            int oldClassSize = message.getClass_size();
             message.changeCoordinates(node1, node2, class_size);
+            //message.resizeTrail(oldClassSize);
         }
     }
 

--- a/Application/src/view/visuals/Draw.java
+++ b/Application/src/view/visuals/Draw.java
@@ -13,9 +13,10 @@ import view.visuals.component.*;
 import java.util.ArrayList;
 
 /**
- * @version 2.0
+ * @version 2.1
  * @author Pontus Laestadius, Sebastian Fransson
- * Collaborator Rashad Kamsheh, Kosara Golemshinska, Isabelle Törnqvist
+ * Collaborators Rashad Kamsheh, Kosara Golemshinska, Isabelle Törnqvist
+ * Touched by Tim Jonasson
  */
 
 public class Draw {

--- a/Application/src/view/visuals/component/Message.java
+++ b/Application/src/view/visuals/component/Message.java
@@ -154,15 +154,19 @@ public class Message implements Renderable {
     public void changeCoordinates(Coordinates node1, Coordinates node2, int class_size){
         this.node1 = node1;
         this.node2 = node2;
-        double class_size_change = (double)class_size/this.class_size;
         this.class_size = class_size;
+    }
 
-        //Checks if there is an existing trail for this message
+    public void resizeTrail(int oldClassSize){
+         //Checks if there is an existing trail for this message
         if(trails.size() == 0){
             return;
         }
         //Calculates the new size for the trail
         double trailsize = class_size/trailScale;
+        double class_size_change = (double)class_size/oldClassSize;
+
+        System.out.println(class_size_change);
 
         //Makes sure the trails doesnt move too much to the left
         int firstTrail = (int)(trails.get(0).getXcoordinate() * class_size_change);
@@ -183,18 +187,11 @@ public class Message implements Renderable {
         if(firstX < leftmostnode) {
             trailOffset = leftmostnode - firstX;
         }
-
-
-        //Calculates the new positions
         for(Trail t: trails){
-            t.setWidth(trailsize);
-            t.setHeight(trailsize);
-            int oldX = t.getXcoordinate();
-            t.setXcoordinate((int)(oldX * class_size_change + trailOffset));
+            t.resize(trailsize, class_size_change, trailOffset);
         }
 
     }
-
 
     /**
      * Renders a message on the canvas using the provided coordinates.
@@ -237,6 +234,8 @@ public class Message implements Renderable {
      */
     public void renderDefault(GraphicsContext gc) {
 
+
+
         //Draw trail for the message, for each instance in the arraylist
         for (Trail t: trails)
             gc.drawImage(trail, t.getXcoordinate(), (t.getYcoordinate() + 18), t.getWidth(), t.getHeight());
@@ -247,6 +246,12 @@ public class Message implements Renderable {
         //toNode Coordinates.
         int x2 = this.node2.getX(); //Not used atm.
         // int y2 = this.node2.getY(); //Not used atm.
+
+        //if ()
+
+        //int d = x1-x2;
+        //for (int i = 0; i < d; i+= size/5)
+        //    gc.drawImage(trail, x1+i, y1, size/5, size/5);
 
         y1 += offset; // Sets an offset from the previous message.
 
@@ -347,4 +352,7 @@ public class Message implements Renderable {
 
 	}
 
+	public int getClass_size(){
+	    return this.class_size;
+    }
 }

--- a/Application/src/view/visuals/component/Message.java
+++ b/Application/src/view/visuals/component/Message.java
@@ -160,20 +160,24 @@ public class Message implements Renderable {
     public void resizeTrail(int oldClassSize){
          //Checks if there is an existing trail for this message
 
+        //If there is no trail
         if(trails.size() == 0){
             return;
         }
+        //Calculates the new size of the trail image and the difference between the window size
         double trailsize = class_size/trailScale;
         double class_size_change = (double)class_size/oldClassSize;
 
         //Makes sure the trails doesnt move too much to the left
         int firstX = (int)(trails.get(0).getXcoordinate() * class_size_change);
         int trailOffset;
+        //Calculates the offset depending on the direction of the message
         if(node2.getX() < node1.getX()) {
             trailOffset = node2.getX() - firstX;
         } else {
             trailOffset = node1.getX() - firstX;
         }
+        //resizes all the trails
         for(Trail t: trails){
             t.resize(trailsize, class_size_change, trailOffset);
         }

--- a/Application/src/view/visuals/component/Message.java
+++ b/Application/src/view/visuals/component/Message.java
@@ -9,8 +9,8 @@ import java.util.ArrayList;
 /**
  * Class for creating the messages to pass between "classes".
  * @author Sebastian Fransson
- * Collaborator Rashad Kamsheh, Isabelle Törnqvist, Pontus Laestadius
- * @version 4.1
+ * Collaborator Rashad Kamsheh, Isabelle Törnqvist, Pontus Laestadius, Tim Jonasson
+ * @version 4.2
  */
 public class Message implements Renderable {
     private String name;

--- a/Application/src/view/visuals/component/Message.java
+++ b/Application/src/view/visuals/component/Message.java
@@ -154,7 +154,40 @@ public class Message implements Renderable {
     public void changeCoordinates(Coordinates node1, Coordinates node2, int class_size){
         this.node1 = node1;
         this.node2 = node2;
+        double class_size_change = (double)class_size/this.class_size;
         this.class_size = class_size;
+
+        if(trails.size() == 0){
+            return;
+        }
+        double trailsize = class_size/trailScale;
+        int firstTrail = (int)(trails.get(0).getXcoordinate() * class_size_change);
+        int lastTrail = (int)(trails.get(trails.size() - 1).getXcoordinate() * class_size_change);
+        int firstX;
+        int trailOffset = 0;
+        if(firstTrail > lastTrail){
+            firstX = lastTrail;
+        } else {
+            firstX = firstTrail;
+        }
+        if(firstX < node1.getX()) {
+            trailOffset = node1.getX() - firstX;
+        }
+
+
+        for(Trail t: trails){
+            t.setWidth(trailsize);
+            t.setHeight(trailsize);
+            int oldX = t.getXcoordinate();
+            int oldY = t.getYcoordinate();
+            t.setXcoordinate((int)(oldX * class_size_change + trailOffset));
+            //t.setYcoordinate((int)(oldY * class_size_change));
+            System.out.println("class_size = " + class_size);
+            System.out.println("class_size change value = " + class_size_change);
+            System.out.println("X: " + t.getXcoordinate());
+            System.out.println("Y: " + t.getYcoordinate());
+        }
+
     }
 
 

--- a/Application/src/view/visuals/component/Message.java
+++ b/Application/src/view/visuals/component/Message.java
@@ -159,33 +159,20 @@ public class Message implements Renderable {
 
     public void resizeTrail(int oldClassSize){
          //Checks if there is an existing trail for this message
+
         if(trails.size() == 0){
             return;
         }
-        //Calculates the new size for the trail
         double trailsize = class_size/trailScale;
         double class_size_change = (double)class_size/oldClassSize;
 
-        System.out.println(class_size_change);
-
         //Makes sure the trails doesnt move too much to the left
-        int firstTrail = (int)(trails.get(0).getXcoordinate() * class_size_change);
-        int lastTrail = (int)(trails.get(trails.size() - 1).getXcoordinate() * class_size_change);
-        int firstX;
-        int trailOffset = 0;
-        if(firstTrail > lastTrail){
-            firstX = lastTrail;
+        int firstX = (int)(trails.get(0).getXcoordinate() * class_size_change);
+        int trailOffset;
+        if(node2.getX() < node1.getX()) {
+            trailOffset = node2.getX() - firstX;
         } else {
-            firstX = firstTrail;
-        }
-        int leftmostnode;
-        if(node1.getX() > node2.getX()){
-            leftmostnode = node2.getX();
-        } else {
-            leftmostnode = node1.getX();
-        }
-        if(firstX < leftmostnode) {
-            trailOffset = leftmostnode - firstX;
+            trailOffset = node1.getX() - firstX;
         }
         for(Trail t: trails){
             t.resize(trailsize, class_size_change, trailOffset);

--- a/Application/src/view/visuals/component/Message.java
+++ b/Application/src/view/visuals/component/Message.java
@@ -172,11 +172,8 @@ public class Message implements Renderable {
         int firstX = (int)(trails.get(0).getXcoordinate() * class_size_change);
         int trailOffset;
         //Calculates the offset depending on the direction of the message
-        if(node2.getX() < node1.getX()) {
-            trailOffset = node2.getX() - firstX;
-        } else {
-            trailOffset = node1.getX() - firstX;
-        }
+        trailOffset = node1.getX() - firstX;
+
         //resizes all the trails
         for(Trail t: trails){
             t.resize(trailsize, class_size_change, trailOffset);

--- a/Application/src/view/visuals/component/Message.java
+++ b/Application/src/view/visuals/component/Message.java
@@ -157,10 +157,14 @@ public class Message implements Renderable {
         double class_size_change = (double)class_size/this.class_size;
         this.class_size = class_size;
 
+        //Checks if there is an existing trail for this message
         if(trails.size() == 0){
             return;
         }
+        //Calculates the new size for the trail
         double trailsize = class_size/trailScale;
+
+        //Makes sure the trails doesnt move too much to the left
         int firstTrail = (int)(trails.get(0).getXcoordinate() * class_size_change);
         int lastTrail = (int)(trails.get(trails.size() - 1).getXcoordinate() * class_size_change);
         int firstX;
@@ -170,22 +174,23 @@ public class Message implements Renderable {
         } else {
             firstX = firstTrail;
         }
-        if(firstX < node1.getX()) {
-            trailOffset = node1.getX() - firstX;
+        int leftmostnode;
+        if(node1.getX() > node2.getX()){
+            leftmostnode = node2.getX();
+        } else {
+            leftmostnode = node1.getX();
+        }
+        if(firstX < leftmostnode) {
+            trailOffset = leftmostnode - firstX;
         }
 
 
+        //Calculates the new positions
         for(Trail t: trails){
             t.setWidth(trailsize);
             t.setHeight(trailsize);
             int oldX = t.getXcoordinate();
-            int oldY = t.getYcoordinate();
             t.setXcoordinate((int)(oldX * class_size_change + trailOffset));
-            //t.setYcoordinate((int)(oldY * class_size_change));
-            System.out.println("class_size = " + class_size);
-            System.out.println("class_size change value = " + class_size_change);
-            System.out.println("X: " + t.getXcoordinate());
-            System.out.println("Y: " + t.getYcoordinate());
         }
 
     }

--- a/Application/src/view/visuals/component/Message.java
+++ b/Application/src/view/visuals/component/Message.java
@@ -232,14 +232,8 @@ public class Message implements Renderable {
         int x1 = this.node1.getX();
         int y1 = this.node1.getY();
         //toNode Coordinates.
-        int x2 = this.node2.getX(); //Not used atm.
+        int x2 = this.node2.getX();
         // int y2 = this.node2.getY(); //Not used atm.
-
-        //if ()
-
-        //int d = x1-x2;
-        //for (int i = 0; i < d; i+= size/5)
-        //    gc.drawImage(trail, x1+i, y1, size/5, size/5);
 
         y1 += offset; // Sets an offset from the previous message.
 

--- a/Application/src/view/visuals/component/Trail.java
+++ b/Application/src/view/visuals/component/Trail.java
@@ -23,6 +23,12 @@ public class Trail {
         this.height = height;
     }
 
+    /**
+     * method for resizing the trail
+     * @param trailsize the new size of the trail
+     * @param class_size_change the difference in window size since last update
+     * @param trailOffset 
+     */
     public void resize(double trailsize, double class_size_change, int trailOffset){
 
         //Calculates the new position
@@ -56,19 +62,35 @@ public class Trail {
      */
     public double getHeight(){return height;}
 
+    /**
+     * setter for the x coordinate
+     * @param xcoordinate
+     */
+
     public void setXcoordinate(int xcoordinate){
         this.xcoordinate = xcoordinate;
     }
 
-
+    /**
+     * setter for the y coordinate
+     * @param ycoordinate
+     */
     public void setYcoordinate(int ycoordinate){
         this.ycoordinate = ycoordinate;
     }
 
+    /**
+     * setter for the width
+     * @param width
+     */
     public void setWidth(double width){
         this.width = width;
     }
 
+    /**
+     * setter for the height
+     * @param height
+     */
     public void setHeight(double height){
         this.height = height;
     }

--- a/Application/src/view/visuals/component/Trail.java
+++ b/Application/src/view/visuals/component/Trail.java
@@ -3,7 +3,8 @@ package view.visuals.component;
 /**
  * Class for the trail
  * @author Isabelle Törnqvist
- * @version 1.0
+ * @contributor Tim Jonasson
+ * @version 1.1
  */
 
 public class Trail {

--- a/Application/src/view/visuals/component/Trail.java
+++ b/Application/src/view/visuals/component/Trail.java
@@ -23,6 +23,15 @@ public class Trail {
         this.height = height;
     }
 
+    public void resize(double trailsize, double class_size_change, int trailOffset){
+
+        //Calculates the new position
+        this.setWidth(trailsize);
+        this.setHeight(trailsize);
+        int oldX = this.getXcoordinate();
+        this.setXcoordinate((int)(oldX * class_size_change + trailOffset));
+    }
+
     /**
      * Getter method for getting the x-coordinate for the trail image
      * @return xcoordinate

--- a/Application/src/view/visuals/component/Trail.java
+++ b/Application/src/view/visuals/component/Trail.java
@@ -47,4 +47,20 @@ public class Trail {
      */
     public double getHeight(){return height;}
 
+    public void setXcoordinate(int xcoordinate){
+        this.xcoordinate = xcoordinate;
+    }
+
+
+    public void setYcoordinate(int ycoordinate){
+        this.ycoordinate = ycoordinate;
+    }
+
+    public void setWidth(double width){
+        this.width = width;
+    }
+
+    public void setHeight(double height){
+        this.height = height;
+    }
 }


### PR DESCRIPTION
The scaling works kinda with this update.
- They will start to overlap if you resize several times
- Messages going from right to left starts with the first trail at the destination node, if someone can figure out why this happens it would be great. 

I feel like this is enough for this task since it drastically improves it and we dont have the time or budget to put more effort into this